### PR TITLE
feat: Add showcase mode for public deployment

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -151,12 +151,13 @@ export default function Home() {
       {isDemoMode && (
         <div className="bg-gradient-to-r from-amber-50 to-orange-50 border-b border-amber-200">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-            <div className="flex items-center justify-center text-sm text-amber-800">
-              <svg className="w-5 h-5 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="flex items-center justify-center text-xs sm:text-sm text-amber-800 text-center">
+              <svg className="w-4 h-4 sm:w-5 sm:h-5 mr-1 sm:mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
-              <span className="font-medium">Demo Mode:</span>
-              <span className="ml-1">This is a preview. Authentication and backend features are disabled.</span>
+              <span className="font-medium">Showcase:</span>
+              <span className="ml-1 hidden sm:inline">This is a preview. Authentication and backend features are disabled.</span>
+              <span className="ml-1 sm:hidden">Preview mode. Authentication disabled.</span>
             </div>
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ export default function Home() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const [isVideoModalOpen, setIsVideoModalOpen] = useState(false);
+  const isDemoMode = process.env.NEXT_PUBLIC_DEMO_MODE === 'true';
 
   if (status === "loading") {
     return (
@@ -145,6 +146,21 @@ export default function Home() {
           </div>
         </div>
       </header>
+
+      {/* Demo Mode Banner */}
+      {isDemoMode && (
+        <div className="bg-gradient-to-r from-amber-50 to-orange-50 border-b border-amber-200">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <div className="flex items-center justify-center text-sm text-amber-800">
+              <svg className="w-5 h-5 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span className="font-medium">Demo Mode:</span>
+              <span className="ml-1">This is a preview. Authentication and backend features are disabled.</span>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Hero Section */}
       <section className="relative py-12 sm:py-20 lg:py-32 overflow-hidden">

--- a/components/GetStartedButton.tsx
+++ b/components/GetStartedButton.tsx
@@ -36,8 +36,8 @@ export default function GetStartedButton({ className, children, variant = 'heade
       
       {/* Demo mode tooltip */}
       {isDemoMode && showTooltip && (
-        <div className="absolute z-50 px-3 py-2 text-sm text-white bg-gray-900 rounded-lg shadow-lg whitespace-nowrap -top-12 left-1/2 transform -translate-x-1/2">
-          <div className="absolute w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-gray-900 left-1/2 transform -translate-x-1/2 -bottom-1.5"></div>
+        <div className="absolute z-50 px-3 py-2 text-sm text-white bg-gray-900 rounded-lg shadow-lg whitespace-nowrap top-full mt-2 left-1/2 transform -translate-x-1/2">
+          <div className="absolute w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-b-[6px] border-b-gray-900 left-1/2 transform -translate-x-1/2 -top-1.5"></div>
           This is a demo. Authentication is disabled.
         </div>
       )}

--- a/components/GetStartedButton.tsx
+++ b/components/GetStartedButton.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { signIn } from "next-auth/react"
+import { useState } from "react"
 
 interface GetStartedButtonProps {
   className?: string
@@ -9,29 +10,37 @@ interface GetStartedButtonProps {
 }
 
 export default function GetStartedButton({ className, children, variant = 'header' }: GetStartedButtonProps) {
+  const [showTooltip, setShowTooltip] = useState(false)
+  
   // Check if we're in demo mode
   const isDemoMode = process.env.NEXT_PUBLIC_DEMO_MODE === 'true'
 
   const handleClick = (e: React.MouseEvent) => {
     if (isDemoMode) {
       e.preventDefault()
+      setShowTooltip(true)
+      setTimeout(() => setShowTooltip(false), 3000)
       return
     }
     signIn("google")
   }
 
-  // Add disabled styling when in demo mode
-  const buttonClassName = isDemoMode 
-    ? `${className} opacity-60 cursor-not-allowed`
-    : className
-
   return (
-    <button
-      onClick={handleClick}
-      className={buttonClassName}
-      disabled={isDemoMode}
-    >
-      {children}
-    </button>
+    <div className="relative inline-block">
+      <button
+        onClick={handleClick}
+        className={className}
+      >
+        {children}
+      </button>
+      
+      {/* Demo mode tooltip */}
+      {isDemoMode && showTooltip && (
+        <div className="absolute z-50 px-3 py-2 text-sm text-white bg-gray-900 rounded-lg shadow-lg whitespace-nowrap -top-12 left-1/2 transform -translate-x-1/2">
+          <div className="absolute w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-gray-900 left-1/2 transform -translate-x-1/2 -bottom-1.5"></div>
+          This is a demo. Authentication is disabled.
+        </div>
+      )}
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add showcase mode for public deployments using `NEXT_PUBLIC_DEMO_MODE=true`
- Disable authentication and show informative banner when enabled
- Responsive design for both mobile and desktop displays

## Changes
- ✨ Add showcase banner with responsive text for mobile/desktop
- 🚫 Disable authentication buttons with helpful tooltip in showcase mode  
- 📱 Mobile-optimized banner sizing and messaging
- 🎨 Smooth tooltip positioning that doesn't overflow viewport

## Test plan
- [x] Test showcase banner displays correctly on mobile and desktop
- [x] Test authentication buttons show tooltip when clicked in showcase mode
- [x] Test normal functionality when `NEXT_PUBLIC_DEMO_MODE=false`
- [x] Test responsive design on different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)